### PR TITLE
Sample receiver and sender registering with service at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 env/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 env/
 .vscode/
+__pycache__/

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,8 @@
+# Serial numbers
+SENDER_SERIAL_NUMBER = 'd7TxFn7o'
+RECEIVER_SERIAL_NUMBER = 'z7VBn9aK'
+
+# Endpoints
+DEVICE_ENDPOINT = 'http://localhost:8080/device'
+ENCODER_ENDPOINT = 'http://localhost:8080/encoder'
+DECODER_ENDPOINT = 'http://localhost:8080/decoder'

--- a/receiver.py
+++ b/receiver.py
@@ -22,7 +22,7 @@ def receive(ip):
     
     # The following simply runs the following command
     # ffplay -autoexit udp://<ip>:23000
-    subprocess.call(['ffplay', '-autoexit', f'udp://{ip}:23000'])
+    subprocess.call(['ffplay', '-v', 'warning', '-stats', f'udp://{ip}:23000'])
 
 if __name__ == '__main__':
     receive()

--- a/receiver.py
+++ b/receiver.py
@@ -1,12 +1,28 @@
 import click
 import subprocess
+import requests
 
 @click.command()
 @click.option('--ip', required=True)
 def receive(ip):
-    subprocess.call(['ffplay', '-autoexit', f'udp://{ip}:23000'])
-    # The above simply runs the following command
+    # Register the receiver with the service
+    serial_number = 'z7VBn9aK'
+    response = requests.get(f'http://localhost:8080/device/{serial_number}')
+    if response.status_code == 200:
+        click.echo(f'Device with serial number {serial_number} is already registered.')
+    else:
+        payload = {'serialNumber': serial_number, 'displayName': 'sample_receiver', 'status': 'Running'}
+        url = 'http://localhost:8080/device'
+        r = requests.post(url, json = payload)
+        payload2 = {'serialNumber': serial_number}
+        url2 = 'http://localhost:8080/decoder'
+        r2 = requests.post(url2, json = payload2)
+        if r2.status_code == 201:
+            click.echo(f'Decoder with serial number {serial_number} has been successfully registered.')
+    
+    # The following simply runs the following command
     # ffplay -autoexit udp://<ip>:23000
+    subprocess.call(['ffplay', '-autoexit', f'udp://{ip}:23000'])
 
 if __name__ == '__main__':
     receive()

--- a/receiver.py
+++ b/receiver.py
@@ -1,27 +1,24 @@
-import click
 import subprocess
+import click
 import requests
+
+from constants import RECEIVER_SERIAL_NUMBER, DEVICE_ENDPOINT, DECODER_ENDPOINT
 
 @click.command()
 @click.option('--ip', required=True)
 def receive(ip):
     # Register the receiver with the service
-    serial_number = 'z7VBn9aK'
-    response = requests.get(f'http://localhost:8080/device/{serial_number}')
-    if response.status_code == 200:
-        click.echo(f'Device with serial number {serial_number} is already registered.')
-    else:
-        payload = {'serialNumber': serial_number, 'displayName': 'sample_receiver', 'status': 'Running'}
-        url = 'http://localhost:8080/device'
-        r = requests.post(url, json = payload)
-        payload2 = {'serialNumber': serial_number}
-        url2 = 'http://localhost:8080/decoder'
-        r2 = requests.post(url2, json = payload2)
-        if r2.status_code == 201:
-            click.echo(f'Decoder with serial number {serial_number} has been successfully registered.')
+    response = requests.get(f'{DEVICE_ENDPOINT}/{RECEIVER_SERIAL_NUMBER}')
+    if response.status_code == 404:
+        device_payload = {'serialNumber': RECEIVER_SERIAL_NUMBER, 'displayName': 'sample_receiver', 'status': 'Running'}
+        r = requests.post(DEVICE_ENDPOINT, json = device_payload)
+        decoder_payload = {'serialNumber': RECEIVER_SERIAL_NUMBER}
+        r = requests.post(DECODER_ENDPOINT, json = decoder_payload)
+        if r.status_code == 201:
+            click.echo(f'Decoder with serial number {RECEIVER_SERIAL_NUMBER} has been successfully registered.')
     
-    # The following simply runs the following command
-    # ffplay -autoexit udp://<ip>:23000
+    # This simply runs the following command
+    # ffplay -v warning -stats udp://<ip>:23000
     subprocess.call(['ffplay', '-v', 'warning', '-stats', f'udp://{ip}:23000'])
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ffmpeg-python
 click
+requests

--- a/sender.py
+++ b/sender.py
@@ -24,7 +24,7 @@ def send(file, ip):
     # The following simply runs the following command
     # ffmpeg -i <input> -f mpegts udp://<ip>:23000
     stream = ffmpeg.input(file)
-    stream = ffmpeg.output(stream, f'udp://{ip}:23000', format = 'mpegts')
+    stream = ffmpeg.output(stream, f'udp://{ip}:23000', f = 'mpegts', v = 'warning', stats = None)
     ffmpeg.run(stream)
 
 if __name__ == '__main__':

--- a/sender.py
+++ b/sender.py
@@ -1,15 +1,31 @@
 import ffmpeg
 import click
+import requests
 
 @click.command()
 @click.option('--file', required=True)
 @click.option('--ip', required=True)
 def send(file, ip):
+    # Register the sender with the service
+    serial_number = 'd7TxFn7o'
+    response = requests.get(f'http://localhost:8080/device/{serial_number}')
+    if response.status_code == 200:
+        click.echo(f'Device with serial number {serial_number} is already registered.')
+    else:
+        payload = {'serialNumber': serial_number, 'displayName': 'sample_sender', 'status': 'Running'}
+        url = 'http://localhost:8080/device'
+        r = requests.post(url, json = payload)
+        payload2 = {'serialNumber': serial_number}
+        url2 = 'http://localhost:8080/encoder'
+        r2 = requests.post(url2, json = payload2)
+        if r2.status_code == 201:
+            click.echo(f'Encoder with serial number {serial_number} has been successfully registered.')
+    
+    # The following simply runs the following command
+    # ffmpeg -i <input> -f mpegts udp://<ip>:23000
     stream = ffmpeg.input(file)
     stream = ffmpeg.output(stream, f'udp://{ip}:23000', format = 'mpegts')
     ffmpeg.run(stream)
-    # The above simply runs the following command
-    # ffmpeg -i <input> -f mpegts udp://<ip>:23000
 
 if __name__ == '__main__':
     send()


### PR DESCRIPTION
This PR tackles issues [#3](https://github.com/felixlapierre/switchboard/issues/3)  and [#4](https://github.com/felixlapierre/switchboard/issues/4)
Obviously, a prerequisite for this to work is to have the service running

If everything works correctly, when retrieving all devices you should be able to see the sample sender and receiver you just created like so:
![image](https://user-images.githubusercontent.com/43392224/95513358-37205480-0988-11eb-88a5-abca72f770bd.png)
