### PR TITLE
[#97] Use the SRT protocol in samples

### DIFF
--- a/receiver.py
+++ b/receiver.py
@@ -18,8 +18,8 @@ def receive(ip):
             click.echo(f'Decoder with serial number {RECEIVER_SERIAL_NUMBER} has been successfully registered.')
     
     # This simply runs the following command
-    # ffplay -v warning -stats udp://<ip>:23000
-    subprocess.call(['ffplay', '-v', 'warning', '-stats', f'udp://{ip}:23000'])
+    # ffplay -v warning -stats -exitonkeydown srt://127.0.0.1:23000?mode=listener
+    subprocess.call(['ffplay', '-v', 'warning', '-stats', '-exitonkeydown', f'srt://{ip}:23000?mode=listener'])
 
 if __name__ == '__main__':
     receive()

--- a/sender.py
+++ b/sender.py
@@ -19,9 +19,9 @@ def send(file, ip):
             click.echo(f'Encoder with serial number {SENDER_SERIAL_NUMBER} has been successfully registered.')
     
     # This simply runs the following command
-    # ffmpeg -i <input> -f mpegts -v warning -stats udp://<ip>:23000
-    stream = ffmpeg.input(file)
-    stream = ffmpeg.output(stream, f'udp://{ip}:23000', f = 'mpegts', v = 'warning', stats = None)
+    # ffmpeg -re -i <input> -f mpegts -v warning -stats srt://<ip>:23000?pkt_size=1316
+    stream = ffmpeg.input(file, re = None)
+    stream = ffmpeg.output(stream, f'srt://{ip}:23000?pkt_size=1316', f = 'mpegts', v = 'warning', stats = None)
     ffmpeg.run(stream)
 
 if __name__ == '__main__':


### PR DESCRIPTION
* The Windows ffmpeg build is compiled with SRT enabled out of the box (option "--enable-libsrt") so everything should work fine
* We might need to use the srt-live-transmit tool in the future (as suggested in multiple tutorials I found online)