### PR TITLE
[#194] Enable rendezvous mode in the sample apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env/
 .vscode/
 __pycache__/
+.idea/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ https://github.com/felixlapierre/switchboard
 # Requirements
 * [Python](https://www.python.org) 3.7.3+
 * [ffmpeg](https://ffmpeg.org) 4.1.6+
+* [srt-live-transmit](https://github.com/Haivision/srt) 1.4.2+ 
 
 # Usage
 1. Create your virtual environment and install the required packages  

--- a/src/constants.py
+++ b/src/constants.py
@@ -11,3 +11,8 @@ DEVICE_ENDPOINT = "http://localhost:8080/device"
 ENCODER_ENDPOINT = "http://localhost:8080/encoder"
 DECODER_ENDPOINT = "http://localhost:8080/decoder"
 STREAM_ENDPOINT = "http://localhost:8080/stream"
+
+#Streaming
+SRT_SCHEME = "srt"
+UDP_SCHEME = "udp"
+LOCAL_HOST = "127.0.0.1"

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -29,23 +29,23 @@ def receive():
     continue_receiving = True
     while continue_receiving:
         ip, port, is_rendezvous = receiver.consume_stream()
-        if ip and port and is_rendezvous:
-            time.sleep(3)
+        time.sleep(0.05)
+        if ip and port:
             if is_rendezvous:
+                subprocess.Popen(
+                    [
+                        "srt-live-transmit",
+                        f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous",
+                        f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}"
+                    ]
+                )
+
                 subprocess.Popen(
                     [
                         "ffplay",
                         "-v",
                         "warning",
                         f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}",
-                    ]
-                )
-
-                subprocess.Popen(
-                    [
-                        "srt-live-transmit",
-                        f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous",
-                        f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}"
                     ]
                 )
             else:

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -30,27 +30,33 @@ def receive():
     while continue_receiving:
         ip, port, is_rendezvous = receiver.consume_stream()
         if ip and port and is_rendezvous:
-            subprocess.Popen(
+            time.sleep(3)
+            if is_rendezvous:
+                subprocess.Popen(
                     [
                         "ffplay",
                         "-v",
                         "warning",
                         f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}",
                     ]
-            )
+                )
 
-            if is_rendezvous:
-                srt_url = f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous"
+                subprocess.Popen(
+                    [
+                        "srt-live-transmit",
+                        f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous",
+                        f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}"
+                    ]
+                )
             else:
-                srt_url = f"{SRT_SCHEME}://{ip}:{port}?mode=listener"
-
-            subprocess.Popen(
-                [
-                    "srt-live-transmit",
-                    srt_url,
-                    f"udp://{LOCAL_HOST}:{INTERNAL_PORT}"
-                ]
-            )
+                subprocess.Popen(
+                    [
+                        "ffplay",
+                        "-v",
+                        "warning",
+                        f"{SRT_SCHEME}://{ip}:{port}?mode=listener",
+                    ]
+                )
 
 
 def register():

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -49,8 +49,8 @@ def receive():
             subprocess.Popen(
                 [
                     "srt-live-transmit",
-                    f"udp://{LOCAL_HOST}:{INTERNAL_PORT}",
-                    srt_url
+                    srt_url,
+                    f"udp://{LOCAL_HOST}:{INTERNAL_PORT}"
                 ]
             )
 

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -3,11 +3,9 @@ from tkinter import *
 from tkinter import filedialog, messagebox
 from receiver import Receiver
 from threading import Thread
+from constants import UDP_SCHEME, LOCAL_HOST, SRT_SCHEME
 
-SRT_SCHEME = "srt"
-UDP_SCHEME = "udp"
-LOCAL_HOST = "127.0.0.1"
-INTERNAL_PORT = 5000
+INTERNAL_PORT = 5001
 
 
 def on_close_window():

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -35,7 +35,14 @@ def receive():
                 mode = "rendezvous"
 
             query = urlencode(dict(mode=mode))
-            url = urlunsplit((SRT_SCHEME, f"{ip}:{port}", "", query, ""))
+
+            if ':' in ip:
+                url = urlunsplit((SRT_SCHEME, f"[{ip}]:{port}", "", query, ""))
+            else:
+                url = urlunsplit((SRT_SCHEME, f"{ip}:{port}", "", query, ""))
+
+            print(f'opening to {url}')
+
             subprocess.Popen(
                 [
                     "ffplay",

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -70,7 +70,7 @@ class Receiver:
     def consume_stream(self):
         if self.pending_streams:
             stream = self.pending_streams.pop(0)
-            ip = stream["outputChannel"]["encoder"]["device"]["privateIpAddress"]
+            ip = stream["outputChannel"]["encoder"]["device"]["publicIpAddress"]
             port = stream["inputChannel"]["channel"]["port"]
             is_rendezvous = bool(stream["isRendezvous"])
             self.completed_streams.append(stream)

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -76,4 +76,4 @@ class Receiver:
             self.completed_streams.append(stream)
             return (ip, port, is_rendezvous)
         else:
-            return (None, None)
+            return (None, None, None)

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -67,7 +67,7 @@ class Receiver:
                 if new_stream_found:
                     self.pending_streams.append(stream)
 
-    def consume_stream(self):
+    def consume_stream(self) -> (str, str, bool):
         if self.pending_streams:
             stream = self.pending_streams.pop(0)
             ip = stream["outputChannel"]["encoder"]["device"]["publicIpAddress"]

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -72,7 +72,8 @@ class Receiver:
             stream = self.pending_streams.pop(0)
             ip = stream["outputChannel"]["encoder"]["device"]["privateIpAddress"]
             port = stream["inputChannel"]["channel"]["port"]
+            is_rendezvous = bool(stream["isRendezvous"])
             self.completed_streams.append(stream)
-            return (ip, port)
+            return (ip, port, is_rendezvous)
         else:
             return (None, None)

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -35,9 +35,6 @@ def send(use_webcam: bool):
         if ip and port and is_rendezvous:
             time.sleep(3)
             if is_rendezvous:
-                ffmpeg_url = f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}?pkt_size=1316"
-                start_ffmpeg(use_webcam, webcam, ffmpeg_url)
-
                 subprocess.Popen(
                     [
                         "srt-live-transmit",
@@ -45,6 +42,9 @@ def send(use_webcam: bool):
                         f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous"
                     ]
                 )
+
+                ffmpeg_url = f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}?pkt_size=1316"
+                start_ffmpeg(use_webcam, webcam, ffmpeg_url)
             else:
                 ffmpeg_url = f"{SRT_SCHEME}://{ip}:{port}?pkt_size=1316"
                 start_ffmpeg(use_webcam, webcam, ffmpeg_url)

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -39,7 +39,14 @@ def send_file():
                 query_parameters["mode"] = "rendezvous"
 
             query = urlencode(query_parameters)
-            url = urlunsplit((SRT_SCHEME, f"{ip}:{port}", "", query, ""))
+
+            if ':' in ip:
+                url = urlunsplit((SRT_SCHEME, f"[{ip}]:{port}", "", query, ""))
+            else:
+                url = urlunsplit((SRT_SCHEME, f"{ip}:{port}", "", query, ""))
+
+            print(f'sending to {url}')
+
             subprocess.Popen(
                 [
                     "ffmpeg",

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -32,7 +32,8 @@ def send(use_webcam: bool):
     webcam = config["camera"]["name"]
     while continue_sending:
         ip, port, is_rendezvous = sender.consume_stream()
-        if ip and port and is_rendezvous:
+        time.sleep(0.05)
+        if ip and port:
             time.sleep(3)
             if is_rendezvous:
                 subprocess.Popen(

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -25,26 +25,20 @@ def poll():
         sender.get_streams()
 
 
-def send_file():
+def send(use_webcam: bool):
     global continue_sending
     continue_sending = True
+    with open("config.json") as json_config:
+        config = json.load(json_config)
+    webcam = config["camera"]["name"]
     while continue_sending:
         ip, port, is_rendezvous = sender.consume_stream()
         if ip and port and is_rendezvous:
             time.sleep(3)
-            subprocess.Popen(
-                [
-                    "ffmpeg",
-                    "-re",
-                    "-i",
-                    choose_file_entry.get(),
-                    "-f",
-                    "mpegts",
-                    "-v",
-                    "warning",
-                    f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}?pkt_size=1316",
-                ]
-            )
+            if use_webcam:
+                start_ffmpeg_webcam(webcam)
+            else:
+                start_ffmpeg_file()
 
             if is_rendezvous:
                 srt_url = f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous"
@@ -59,33 +53,37 @@ def send_file():
                 ]
             )
 
+def start_ffmpeg_file():
+    subprocess.Popen(
+        [
+            "ffmpeg",
+            "-re",
+            "-i",
+            choose_file_entry.get(),
+            "-f",
+            "mpegts",
+            "-v",
+            "warning",
+            f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}?pkt_size=1316",
+        ]
+    )
 
-def send_cam():
-    global continue_sending
-    continue_sending = True
-    with open("config.json") as json_config:
-        config = json.load(json_config)
-    webcam = config["camera"]["name"]
-    while continue_sending:
-        ip, port = sender.consume_stream()
-        if ip and port:
-            # To give time for receiver to start
-            # Need to find a more elegant solution in the future
-            time.sleep(3)
-            subprocess.Popen(
-                [
-                    "ffmpeg",
-                    "-f",
-                    "dshow",
-                    "-i",
-                    f"video={webcam}",
-                    "-f",
-                    "mpegts",
-                    "-v",
-                    "warning",
-                    f"srt://{ip}:{port}?pkt_size=1316",
-                ]
-            )
+
+def start_ffmpeg_webcam(webcam: str):
+    subprocess.Popen(
+        [
+            "ffmpeg",
+            "-f",
+            "dshow",
+            "-i",
+            f"video={webcam}",
+            "-f",
+            "mpegts",
+            "-v",
+            "warning",
+            f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}?pkt_size=1316",
+        ]
+    )
 
 
 def register():
@@ -114,14 +112,14 @@ def browse():
 def start():
     if camera_selection.get() == 1:
         Thread(target=poll).start()
-        Thread(target=send_cam).start()
+        Thread(target=send, args=(True,)).start()
     else:
         input_file = choose_file_entry.get()
         if not is_valid_file(input_file):
             messagebox.showerror("Error", "Invalid file type.")
             return
         Thread(target=poll).start()
-        Thread(target=send_file).start()
+        Thread(target=send, args=(False,)).start()
 
 
 def is_valid_file(input_file):

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -1,13 +1,12 @@
 import ipaddress, subprocess, time, json
 from tkinter import *
 from tkinter import filedialog, messagebox
+from constants import SRT_SCHEME, LOCAL_HOST, UDP_SCHEME
 from sender import Sender
 from threading import Thread
 
-SRT_SCHEME = "srt"
-UDP_SCHEME = "udp"
-LOCAL_HOST = "127.0.0.1"
-INTERNAL_PORT = 5000
+INTERNAL_PORT = 5002
+
 
 def on_close_window():
     global continue_polling

--- a/src/sender.py
+++ b/src/sender.py
@@ -70,7 +70,7 @@ class Sender:
     def consume_stream(self):
         if self.pending_streams:
             stream = self.pending_streams.pop(0)
-            ip = stream["inputChannel"]["decoder"]["device"]["privateIpAddress"]
+            ip = stream["inputChannel"]["decoder"]["device"]["publicIpAddress"]
             port = stream["inputChannel"]["channel"]["port"]
             is_rendezvous = stream["mode"]
             self.completed_streams.append(stream)

--- a/src/sender.py
+++ b/src/sender.py
@@ -76,4 +76,4 @@ class Sender:
             self.completed_streams.append(stream)
             return (ip, port, is_rendezvous)
         else:
-            return (None, None)
+            return (None, None, None)

--- a/src/sender.py
+++ b/src/sender.py
@@ -67,7 +67,7 @@ class Sender:
                 if new_stream_found:
                     self.pending_streams.append(stream)
 
-    def consume_stream(self):
+    def consume_stream(self) -> (str, str, bool):
         if self.pending_streams:
             stream = self.pending_streams.pop(0)
             ip = stream["inputChannel"]["decoder"]["device"]["publicIpAddress"]

--- a/src/sender.py
+++ b/src/sender.py
@@ -72,7 +72,8 @@ class Sender:
             stream = self.pending_streams.pop(0)
             ip = stream["inputChannel"]["decoder"]["device"]["privateIpAddress"]
             port = stream["inputChannel"]["channel"]["port"]
+            is_rendezvous = stream["mode"]
             self.completed_streams.append(stream)
-            return (ip, port)
+            return (ip, port, is_rendezvous)
         else:
             return (None, None)

--- a/src/sender.py
+++ b/src/sender.py
@@ -72,7 +72,7 @@ class Sender:
             stream = self.pending_streams.pop(0)
             ip = stream["inputChannel"]["decoder"]["device"]["publicIpAddress"]
             port = stream["inputChannel"]["channel"]["port"]
-            is_rendezvous = stream["mode"]
+            is_rendezvous = bool(stream["isRendezvous"])
             self.completed_streams.append(stream)
             return (ip, port, is_rendezvous)
         else:


### PR DESCRIPTION
# General info
Enable the rendezvous mode on the sample apps
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: #194

**Task description**: 
 - Enable SRT rendezvous mode by using `srt-live-transmit` and `ffmpeg`
 - Changed the stream consume method to get the correct port and the public IP address of the devices
 - Added new dependencies to the README
 - Changed the image paths to work on Linux (I would like for someone to double check that it doesn't break on windows)
 - Small method refactor for the `send_file` and `send_cam` functions

# Testing
Manual testing only

**Test coverage**:
N/A

# Additional notes

**Note to reviewers**:
The new dependency that was added, `srt-live-tansmit`, is part of [SRT](https://github.com/Haivision/srt) and is a pain to install on windows. If you're using windows you'll have to build it yourself. I know, I wish we found another solution for this.
