### PR TITLE
[#280/282] Multiple streams

### DIFF
--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -137,9 +137,7 @@ receiver = Receiver()
 default_font = ("TkDefaultFont", 12)
 
 # Registration section elements
-registration_label_frame = LabelFrame(
-    root, text="Registration", font=default_font, borderwidth=4
-)
+registration_label_frame = LabelFrame(root, text="Registration", font=default_font, borderwidth=4)
 display_name_label = Label(
     registration_label_frame, text="Display Name", font=default_font, width=20
 )

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -5,7 +5,7 @@ from receiver import Receiver
 from threading import Thread
 from constants import UDP_SCHEME, LOCAL_HOST, SRT_SCHEME
 
-INTERNAL_PORT = 5001
+INTERNAL_PORT = 5000
 
 
 def on_close_window():
@@ -52,6 +52,7 @@ def receive():
                         ]
                     ),
                 )
+                INTERNAL_PORT += 1
             else:
                 receiver.processes[stream_id] = [
                     subprocess.Popen(

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -88,12 +88,14 @@ def check_status():
 def register():
     receiver.display_name = display_name_entry.get()
     receiver.serial_number = serial_number_entry.get()
-    channel_port = channel_port_entry.get()
-    if not is_valid_port(channel_port):
+    channel_1_port = channel_1_port_entry.get()
+    channel_2_port = channel_2_port_entry.get()
+    if not is_valid_port(channel_1_port) or not is_valid_port(channel_2_port):
         messagebox.showerror("Error", "Invalid port.")
         return
     else:
-        receiver.channel_port = channel_port
+        receiver.channel_1_port = channel_1_port
+        receiver.channel_2_port = channel_2_port
     return_message = receiver.register()
     if return_message == "Decoder already registered!":
         messagebox.showerror("Error", return_message)
@@ -148,11 +150,16 @@ serial_number_label = Label(
 )
 serial_number_entry = Entry(registration_label_frame, width=30, font=default_font)
 serial_number_entry.insert(0, receiver.serial_number)
-channel_port_label = Label(
-    registration_label_frame, text="Channel Port", width=20, font=default_font
+channel_1_port_label = Label(
+    registration_label_frame, text="Channel 1 Port", width=20, font=default_font
 )
-channel_port_entry = Entry(registration_label_frame, width=30, font=default_font)
-channel_port_entry.insert(0, receiver.channel_port)
+channel_1_port_entry = Entry(registration_label_frame, width=30, font=default_font)
+channel_1_port_entry.insert(0, receiver.channel_1_port)
+channel_2_port_label = Label(
+    registration_label_frame, text="Channel 2 Port", width=20, font=default_font
+)
+channel_2_port_entry = Entry(registration_label_frame, width=30, font=default_font)
+channel_2_port_entry.insert(0, receiver.channel_2_port)
 register_button = Button(
     registration_label_frame,
     text="Register",
@@ -179,8 +186,10 @@ display_name_label.grid(row=0, column=0)
 display_name_entry.grid(row=0, column=1, pady=10)
 serial_number_label.grid(row=1, column=0)
 serial_number_entry.grid(row=1, column=1)
-channel_port_label.grid(row=2, column=0)
-channel_port_entry.grid(row=2, column=1, pady=10)
+channel_1_port_label.grid(row=2, column=0)
+channel_1_port_entry.grid(row=2, column=1, pady=10)
+channel_2_port_label.grid(row=3, column=0)
+channel_2_port_entry.grid(row=3, column=1)
 register_button.grid(row=0, column=2, rowspan=2, padx=20, pady=5)
 listening_label_frame.pack(expand="yes", fill="both")
 start_button.place(relx=0.5, rely=0.5, anchor=CENTER)

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -71,9 +71,7 @@ class Receiver:
                     stream["outputChannel"]["encoder"]["device"]["publicIpAddress"]
                     == "0:0:0:0:0:0:0:1"
                 ):
-                    ip = stream["outputChannel"]["encoder"]["device"][
-                        "privateIpAddress"
-                    ]
+                    ip = stream["outputChannel"]["encoder"]["device"]["privateIpAddress"]
                 else:
                     ip = stream["outputChannel"]["encoder"]["device"]["publicIpAddress"]
                 port = stream["inputChannel"]["channel"]["port"]

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -13,13 +13,15 @@ class Receiver:
         self,
         display_name=RECEIVER_DISPLAY_NAME,
         serial_number=RECEIVER_SERIAL_NUMBER,
-        channel_port="20000",
+        channel_1_port="20002",
+        channel_2_port="20003",
         streams=None,
         processes=None,
     ):
         self.display_name = display_name
         self.serial_number = serial_number
-        self.channel_port = channel_port
+        self.channel_1_port = channel_1_port
+        self.channel_2_port = channel_2_port
         self.streams = streams if streams is not None else []
         self.processes = processes if processes is not None else {}
 
@@ -39,9 +41,15 @@ class Receiver:
                     {
                         "channel": {
                             "name": "Sample Receiver Channel 1",
-                            "port": self.channel_port,
+                            "port": self.channel_1_port,
                         }
-                    }
+                    },
+                    {
+                        "channel": {
+                            "name": "Sample Receiver Channel 2",
+                            "port": self.channel_2_port,
+                        }
+                    },
                 ],
             }
             r = requests.post(DECODER_ENDPOINT, json=decoder_payload)

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -114,12 +114,14 @@ def check_status():
 def register():
     sender.display_name = display_name_entry.get()
     sender.serial_number = serial_number_entry.get()
-    channel_port = channel_port_entry.get()
-    if not is_valid_port(channel_port):
+    channel_1_port = channel_1_port_entry.get()
+    channel_2_port = channel_2_port_entry.get()
+    if not is_valid_port(channel_1_port) or not is_valid_port(channel_2_port):
         messagebox.showerror("Error", "Invalid port.")
         return
     else:
-        sender.channel_port = channel_port
+        sender.channel_1_port = channel_1_port
+        sender.channel_2_port = channel_2_port
     return_message = sender.register()
     if return_message == "Encoder already registered!":
         messagebox.showerror("Error", return_message)
@@ -202,11 +204,16 @@ serial_number_label = Label(
 )
 serial_number_entry = Entry(registration_label_frame, width=30, font=default_font)
 serial_number_entry.insert(0, sender.serial_number)
-channel_port_label = Label(
-    registration_label_frame, text="Channel Port", width=20, font=default_font
+channel_1_port_label = Label(
+    registration_label_frame, text="Channel 1 Port", width=20, font=default_font
 )
-channel_port_entry = Entry(registration_label_frame, width=30, font=default_font)
-channel_port_entry.insert(0, sender.channel_port)
+channel_1_port_entry = Entry(registration_label_frame, width=30, font=default_font)
+channel_1_port_entry.insert(0, sender.channel_1_port)
+channel_2_port_label = Label(
+    registration_label_frame, text="Channel 2 Port", width=20, font=default_font
+)
+channel_2_port_entry = Entry(registration_label_frame, width=30, font=default_font)
+channel_2_port_entry.insert(0, sender.channel_2_port)
 register_button = Button(
     registration_label_frame,
     text="Register",
@@ -254,8 +261,10 @@ display_name_label.grid(row=0, column=0)
 display_name_entry.grid(row=0, column=1, pady=10)
 serial_number_label.grid(row=1, column=0)
 serial_number_entry.grid(row=1, column=1)
-channel_port_label.grid(row=2, column=0)
-channel_port_entry.grid(row=2, column=1, pady=10)
+channel_1_port_label.grid(row=2, column=0)
+channel_1_port_entry.grid(row=2, column=1, pady=10)
+channel_2_port_label.grid(row=3, column=0)
+channel_2_port_entry.grid(row=3, column=1)
 register_button.grid(row=0, column=2, rowspan=2, padx=20, pady=5)
 streaming_label_frame.pack(expand="yes", fill="both")
 choose_file_label.grid(row=0, column=0)

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -129,11 +129,15 @@ def register():
         messagebox.showinfo("Info", return_message)
 
 
-def browse():
+def browse(file):
     root.filename = filedialog.askopenfilename(initialdir="/", title="Select File")
     if root.filename:
-        choose_file_entry.delete(0, "end")
-        choose_file_entry.insert(0, root.filename)
+        if file == 1:
+            choose_file_1_entry.delete(0, "end")
+            choose_file_1_entry.insert(0, root.filename)
+        else:
+            choose_file_2_entry.delete(0, "end")
+            choose_file_2_entry.insert(0, root.filename)
 
 
 def start():
@@ -141,8 +145,12 @@ def start():
         Thread(target=poll).start()
         Thread(target=send, args=(True,)).start()
     else:
-        input_file = choose_file_entry.get()
-        if not is_valid_file(input_file):
+        input_file_1 = choose_file_1_entry.get()
+        input_file_2 = choose_file_2_entry.get()
+        if not input_file_1 or not input_file_2:
+            messagebox.showerror("Error", "Missing one or both files.")
+            return
+        if not is_valid_file(input_file_1) or not is_valid_file(input_file_2):
             messagebox.showerror("Error", "Invalid file type.")
             return
         Thread(target=poll).start()
@@ -227,16 +235,27 @@ register_button = Button(
 streaming_label_frame = LabelFrame(
     root, text="Streaming Instructions", font=default_font, borderwidth=4
 )
-choose_file_label = Label(
-    streaming_label_frame, text="File", font=default_font, width=13
+choose_file_1_label = Label(
+    streaming_label_frame, text="File 1", font=default_font, width=13
 )
-choose_file_entry = Entry(streaming_label_frame, width=40, font=default_font)
-browse_button = Button(
+choose_file_1_entry = Entry(streaming_label_frame, width=40, font=default_font)
+browse_button_1 = Button(
     streaming_label_frame,
     text="Browse",
     font=default_font,
     width=20,
-    command=browse,
+    command=lambda: browse(1),
+)
+choose_file_2_label = Label(
+    streaming_label_frame, text="File 2", font=default_font, width=13
+)
+choose_file_2_entry = Entry(streaming_label_frame, width=40, font=default_font)
+browse_button_2 = Button(
+    streaming_label_frame,
+    text="Browse",
+    font=default_font,
+    width=20,
+    command=lambda: browse(2),
 )
 camera_label = Label(
     streaming_label_frame, text="Use Camera", font=default_font, width=13
@@ -267,9 +286,12 @@ channel_2_port_label.grid(row=3, column=0)
 channel_2_port_entry.grid(row=3, column=1)
 register_button.grid(row=0, column=2, rowspan=2, padx=20, pady=5)
 streaming_label_frame.pack(expand="yes", fill="both")
-choose_file_label.grid(row=0, column=0)
-choose_file_entry.grid(row=0, column=1)
-browse_button.grid(row=0, column=2, padx=20, pady=5)
+choose_file_1_label.grid(row=0, column=0)
+choose_file_1_entry.grid(row=0, column=1)
+browse_button_1.grid(row=0, column=2, padx=20, pady=5)
+choose_file_2_label.grid(row=1, column=0)
+choose_file_2_entry.grid(row=1, column=1)
+browse_button_2.grid(row=1, column=2, padx=20, pady=5)
 camera_label.grid(row=3, column=0)
 camera_checkbox.grid(sticky="W", row=3, column=1)
 start_button.grid(row=3, column=2, pady=10)

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -5,7 +5,7 @@ from constants import SRT_SCHEME, LOCAL_HOST, UDP_SCHEME
 from sender import Sender
 from threading import Thread
 
-INTERNAL_PORT = 5002
+INTERNAL_PORT = 5000
 
 
 def on_close_window():
@@ -55,6 +55,7 @@ def send(use_webcam):
                 sender.processes[stream_id].insert(
                     0, start_ffmpeg(use_webcam, webcam, ffmpeg_url, output_channel_port)
                 )
+                INTERNAL_PORT += 1
             else:
                 ffmpeg_url = f"{SRT_SCHEME}://{ip}:{input_channel_port}?pkt_size=1316"
                 sender.processes[stream_id] = [

--- a/src/sender.py
+++ b/src/sender.py
@@ -74,7 +74,14 @@ class Sender:
                     ip = stream["inputChannel"]["decoder"]["device"]["privateIpAddress"]
                 else:
                     ip = stream["inputChannel"]["decoder"]["device"]["publicIpAddress"]
-                port = stream["inputChannel"]["channel"]["port"]
+                output_channel_port = stream["outputChannel"]["channel"]["port"]
+                input_channel_port = stream["inputChannel"]["channel"]["port"]
                 is_rendezvous = bool(stream["isRendezvous"])
-                return (stream_id, ip, port, is_rendezvous)
-        return (None, None, None, None)
+                return (
+                    stream_id,
+                    ip,
+                    output_channel_port,
+                    input_channel_port,
+                    is_rendezvous,
+                )
+        return (None, None, None, None, None)

--- a/src/sender.py
+++ b/src/sender.py
@@ -13,13 +13,15 @@ class Sender:
         self,
         display_name=SENDER_DISPLAY_NAME,
         serial_number=SENDER_SERIAL_NUMBER,
-        channel_port="20000",
+        channel_1_port="20000",
+        channel_2_port="20001",
         streams=None,
         processes=None,
     ):
         self.display_name = display_name
         self.serial_number = serial_number
-        self.channel_port = channel_port
+        self.channel_1_port = channel_1_port
+        self.channel_2_port = channel_2_port
         self.streams = streams if streams is not None else []
         self.processes = processes if processes is not None else {}
 
@@ -39,9 +41,15 @@ class Sender:
                     {
                         "channel": {
                             "name": "Sample Sender Channel 1",
-                            "port": self.channel_port,
+                            "port": self.channel_1_port,
                         }
-                    }
+                    },
+                    {
+                        "channel": {
+                            "name": "Sample Sender Channel 2",
+                            "port": self.channel_2_port,
+                        }
+                    },
                 ],
             }
             r = requests.post(ENCODER_ENDPOINT, json=encoder_payload)


### PR DESCRIPTION
# General info

**Issue Number**: #280 and #282

**Task description**: 

 - Sample sender allows to select two files and registers itself with two channels
 - Sample receiver registers itself with two channels and is able to receive multiple streams

# Testing

**Test coverage:** n/a

# Additional notes

**Note to reviewers**:
- Simple test:
    (1) Register both devices
    (2) Select the two files to send in the sender
    (3) Start the receiver
    (4) Start the sender
    (5) Create multiple streams in service
The receiver app should start playing all the streams at once.
- Obviously, all previous "features" should still work (i.e. deleting a stream, closing the player, etc.)
- I've taken into account the situation where devices are on separate networks but haven't tested it (although everything should still work)