### PR TITLE
[#277] Sample apps authentication

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,7 @@
 {
     "camera": {
         "name": "HD WebCam"
-    }
+    },
+    "username": "admin",
+    "password": "admin"
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -11,8 +11,9 @@ DEVICE_ENDPOINT = "http://localhost:8080/device"
 ENCODER_ENDPOINT = "http://localhost:8080/encoder"
 DECODER_ENDPOINT = "http://localhost:8080/decoder"
 STREAM_ENDPOINT = "http://localhost:8080/stream"
+AUTH_ENDPOINT = "http://localhost:8080/auth/token"
 
-#Streaming
+# Streaming
 SRT_SCHEME = "srt"
 UDP_SCHEME = "udp"
 LOCAL_HOST = "127.0.0.1"


### PR DESCRIPTION
# General info

**Issue Number**: #277

**Task description**: 

 - Added wrapper method to request calls to handle authentication
 - Sample apps use the credentials in settings.json to first request a JWT token and then use that token in all subsequent calls

# Testing

**Test coverage:** n/a

# Additional notes

**Note to reviewers**:
- This will only work with branch auth-create-stream-bug for the backend until https://github.com/bean-pod/switchboard/pull/352 is merged