### PR TITLE
[#268] SRT Stream Statistics

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,5 +3,8 @@
         "name": "HD WebCam"
     },
     "username": "admin",
-    "password": "admin"
+    "password": "admin",
+    "statistics": {
+        "frequency": 5
+    }
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,6 +12,7 @@ ENCODER_ENDPOINT = "http://localhost:8080/encoder"
 DECODER_ENDPOINT = "http://localhost:8080/decoder"
 STREAM_ENDPOINT = "http://localhost:8080/stream"
 AUTH_ENDPOINT = "http://localhost:8080/auth/token"
+STATISTICS_ENDPOINT = "http://localhost:8080/stream/statistics"
 
 # Streaming
 SRT_SCHEME = "srt"

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -38,6 +38,13 @@ def receive():
                     subprocess.Popen(
                         [
                             "srt-live-transmit",
+                            "-statsout",
+                            f"stats\{stream_id}-stats.json",
+                            "-pf",
+                            "json",
+                            "-s",
+                            "100",
+                            "-f",
                             f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous",
                             f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}",
                         ]

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -96,7 +96,7 @@ def send_statistics(stream_id):
     # While stream is still playing
     while stream_id in receiver.processes:
         if p.exists():
-            with open(f"{stream_id}-stats.json") as json_stats:
+            with open(p) as json_stats:
                 data = json_stats.read().splitlines()
             if data:
                 # Get the most recent (cumulative) stats available

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -6,8 +6,6 @@ from threading import Thread
 from constants import UDP_SCHEME, LOCAL_HOST, SRT_SCHEME
 from pathlib import Path
 
-INTERNAL_PORT = 5000
-
 
 def on_close_window():
     global continue_receiving
@@ -42,7 +40,7 @@ def receive():
                             "100",
                             "-f",
                             f"{SRT_SCHEME}://{ip}:{port}?mode=rendezvous",
-                            f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}",
+                            f"{UDP_SCHEME}://{LOCAL_HOST}:{receiver.internal_port}",
                         ]
                     )
                 ]
@@ -53,13 +51,13 @@ def receive():
                             "ffplay",
                             "-v",
                             "fatal",
-                            f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}",
+                            f"{UDP_SCHEME}://{LOCAL_HOST}:{receiver.internal_port}",
                         ]
                     ),
                 )
                 time.sleep(1)
                 Thread(target=send_statistics, args=(stream_id,)).start()
-                INTERNAL_PORT += 1
+                receiver.internal_port += 1
             else:
                 receiver.processes[stream_id] = [
                     subprocess.Popen(

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -99,46 +99,47 @@ def send_statistics(stream_id):
         with open(f"stats\{stream_id}-stats.json") as json_stats:
             data = json_stats.read()[:-2]
         data = json.loads("[{}]".format(data))
-        # Get the most recent (cumulative) stats available
-        stats = data[-1]
-        # TODO: Newer version of srt-live-transmit outputs more stats
-        # Option #1: Process them on samples end like it's done below to fit our endpoint
-        # Option #2: Make the necessary changes in the backend instead
-        stats = {"id" if k == "sid" else k: v for k, v in stats.items()}
-        stats["id"] = stream_id
-        del stats["timepoint"]
-        del stats["send"]["packetsUnique"]
-        del stats["send"]["packetsFilterExtra"]
-        del stats["send"]["bytesUnique"]
-        del stats["send"]["sendPeriod"]
-        del stats["recv"]["packetsUnique"]
-        del stats["recv"]["packetsFilterExtra"]
-        del stats["recv"]["packetsFilterSupply"]
-        del stats["recv"]["packetsFilterLoss"]
-        del stats["recv"]["bytesUnique"]
-        # Cast to int or double
-        stats["time"] = int(stats["time"])
-        for k, v in stats["window"].items():
-            try:
-                stats["window"][k] = int(v)
-            except ValueError:
-                stats["window"][k] = float(v)
-        for k, v in stats["link"].items():
-            try:
-                stats["link"][k] = int(v)
-            except ValueError:
-                stats["link"][k] = float(v)
-        for k, v in stats["send"].items():
-            try:
-                stats["send"][k] = int(v)
-            except ValueError:
-                stats["send"][k] = float(v)
-        for k, v in stats["recv"].items():
-            try:
-                stats["recv"][k] = int(v)
-            except ValueError:
-                stats["recv"][k] = float(v)
-        receiver.send_stats(stats)
+        if data:
+            # Get the most recent (cumulative) stats available
+            stats = data[-1]
+            # TODO: Newer version of srt-live-transmit outputs more stats
+            # Option #1: Process them on samples end like it's done below to fit our endpoint
+            # Option #2: Make the necessary changes in the backend instead
+            stats = {"id" if k == "sid" else k: v for k, v in stats.items()}
+            stats["id"] = stream_id
+            del stats["timepoint"]
+            del stats["send"]["packetsUnique"]
+            del stats["send"]["packetsFilterExtra"]
+            del stats["send"]["bytesUnique"]
+            del stats["send"]["sendPeriod"]
+            del stats["recv"]["packetsUnique"]
+            del stats["recv"]["packetsFilterExtra"]
+            del stats["recv"]["packetsFilterSupply"]
+            del stats["recv"]["packetsFilterLoss"]
+            del stats["recv"]["bytesUnique"]
+            # Cast to int or double
+            stats["time"] = int(stats["time"])
+            for k, v in stats["window"].items():
+                try:
+                    stats["window"][k] = int(v)
+                except ValueError:
+                    stats["window"][k] = float(v)
+            for k, v in stats["link"].items():
+                try:
+                    stats["link"][k] = int(v)
+                except ValueError:
+                    stats["link"][k] = float(v)
+            for k, v in stats["send"].items():
+                try:
+                    stats["send"][k] = int(v)
+                except ValueError:
+                    stats["send"][k] = float(v)
+            for k, v in stats["recv"].items():
+                try:
+                    stats["recv"][k] = int(v)
+                except ValueError:
+                    stats["recv"][k] = float(v)
+            receiver.send_stats(stats)
         time.sleep(receiver.stats_freq)
     # Delete stats file
     p = Path.cwd() / "stats" / f"{stream_id}-stats.json"

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -139,7 +139,7 @@ def send_statistics(stream_id):
             except ValueError:
                 stats["recv"][k] = float(v)
         receiver.send_stats(stats)
-        time.sleep(5)
+        time.sleep(receiver.stats_freq)
     # Delete stats file
     p = Path.cwd() / "stats" / f"{stream_id}-stats.json"
     p.unlink(missing_ok=True)

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -15,7 +15,7 @@ def on_close_window():
 
 
 def poll():
-    time.sleep(5)
+    time.sleep(3)
     receiver.get_streams()
 
 
@@ -23,8 +23,8 @@ def receive():
     global continue_receiving
     continue_receiving = True
     while continue_receiving:
-        check_status()
         poll()
+        check_status()
         stream_id, ip, port, is_rendezvous = receiver.consume_stream()
         if ip and port:
             if is_rendezvous:

--- a/src/receiver-ui.py
+++ b/src/receiver-ui.py
@@ -4,6 +4,7 @@ from tkinter import filedialog, messagebox
 from receiver import Receiver
 from threading import Thread
 from constants import UDP_SCHEME, LOCAL_HOST, SRT_SCHEME
+from pathlib import Path
 
 INTERNAL_PORT = 5000
 
@@ -13,6 +14,7 @@ def on_close_window():
     continue_polling = False
     global continue_receiving
     continue_receiving = False
+    path_to_stats.rmdir()
     root.destroy()
 
 
@@ -135,6 +137,8 @@ root.title("Switchboard - Sample Receiver")
 root.geometry("800x400")
 root.iconphoto(True, PhotoImage(file=r"public/bean.png"))
 receiver = Receiver()
+path_to_stats = Path.cwd() / "stats"
+path_to_stats.mkdir()
 default_font = ("TkDefaultFont", 12)
 
 # Registration section elements

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -31,6 +31,7 @@ class Receiver:
         with open("config.json") as json_config:
             config = json.load(json_config)
         self.stats_freq = config["statistics"]["frequency"]
+        self.internal_port = 5000
 
     def register(self):
         response = self.request("get", f"{DEVICE_ENDPOINT}/{self.serial_number}")

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -6,6 +6,7 @@ from constants import (
     RECEIVER_SERIAL_NUMBER,
     STREAM_ENDPOINT,
     AUTH_ENDPOINT,
+    STATISTICS_ENDPOINT,
 )
 
 
@@ -91,6 +92,10 @@ class Receiver:
         else:
             return False
 
+    def send_stats(self, stats):
+        r = self.request("put", STATISTICS_ENDPOINT, stats)
+        return r.status_code
+
     def request(self, method, url, data=None):
         if not self.jwt:
             with open("config.json") as json_config:
@@ -107,6 +112,8 @@ class Receiver:
             response = requests.get(url, headers=auth_header)
         elif method == "post":
             response = requests.post(url, json=data, headers=auth_header)
+        elif method == "put":
+            response = requests.put(url, json=data, headers=auth_header)
         else:
             response = requests.delete(url, headers=auth_header)
         if response.status_code == 403:

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -28,6 +28,9 @@ class Receiver:
         self.streams = streams if streams is not None else []
         self.processes = processes if processes is not None else {}
         self.jwt = jwt
+        with open("config.json") as json_config:
+            config = json.load(json_config)
+        self.stats_freq = config["statistics"]["frequency"]
 
     def register(self):
         response = self.request("get", f"{DEVICE_ENDPOINT}/{self.serial_number}")

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -13,7 +13,7 @@ def on_close_window():
 
 
 def poll():
-    time.sleep(5)
+    time.sleep(3)
     sender.get_streams()
 
 
@@ -24,8 +24,8 @@ def send(use_webcam):
         config = json.load(json_config)
     webcam = config["camera"]["name"]
     while continue_sending:
-        check_status()
         poll()
+        check_status()
         (
             stream_id,
             ip,
@@ -34,7 +34,7 @@ def send(use_webcam):
             is_rendezvous,
         ) = sender.consume_stream()
         if ip and input_channel_port:
-            time.sleep(3)
+            time.sleep(1)
             if is_rendezvous:
                 sender.processes[stream_id] = [
                     subprocess.Popen(
@@ -151,7 +151,6 @@ def browse(file):
 
 def start():
     if camera_selection.get() == 1:
-        Thread(target=poll).start()
         Thread(target=send, args=(True,)).start()
     else:
         input_file_1 = choose_file_1_entry.get()

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -5,8 +5,6 @@ from constants import SRT_SCHEME, LOCAL_HOST, UDP_SCHEME
 from sender import Sender
 from threading import Thread
 
-INTERNAL_PORT = 5000
-
 
 def on_close_window():
     global continue_sending
@@ -42,16 +40,16 @@ def send(use_webcam):
                     subprocess.Popen(
                         [
                             "srt-live-transmit",
-                            f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}",
+                            f"{UDP_SCHEME}://{LOCAL_HOST}:{sender.internal_port}",
                             f"{SRT_SCHEME}://{ip}:{input_channel_port}?mode=rendezvous",
                         ]
                     )
                 ]
-                ffmpeg_url = f"{UDP_SCHEME}://{LOCAL_HOST}:{INTERNAL_PORT}?pkt_size=1316"
+                ffmpeg_url = f"{UDP_SCHEME}://{LOCAL_HOST}:{sender.internal_port}?pkt_size=1316"
                 sender.processes[stream_id].insert(
                     0, start_ffmpeg(use_webcam, webcam, ffmpeg_url, output_channel_port)
                 )
-                INTERNAL_PORT += 1
+                sender.internal_port += 1
             else:
                 ffmpeg_url = f"{SRT_SCHEME}://{ip}:{input_channel_port}?pkt_size=1316"
                 sender.processes[stream_id] = [

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -9,19 +9,14 @@ INTERNAL_PORT = 5000
 
 
 def on_close_window():
-    global continue_polling
-    continue_polling = False
     global continue_sending
     continue_sending = False
     root.destroy()
 
 
 def poll():
-    global continue_polling
-    continue_polling = True
-    while continue_polling:
-        time.sleep(5)
-        sender.get_streams()
+    time.sleep(5)
+    sender.get_streams()
 
 
 def send(use_webcam):
@@ -32,6 +27,7 @@ def send(use_webcam):
     webcam = config["camera"]["name"]
     while continue_sending:
         check_status()
+        poll()
         (
             stream_id,
             ip,
@@ -169,7 +165,6 @@ def start():
         file2_valid = is_valid_file(input_file_2) and not input_file_1
         both_valid = is_valid_file(input_file_1) and is_valid_file(input_file_2)
         if file1_valid or file2_valid or both_valid:
-            Thread(target=poll).start()
             Thread(target=send, args=(False,)).start()
         else:
             messagebox.showerror("Error", "Invalid file type.")

--- a/src/sender.py
+++ b/src/sender.py
@@ -27,6 +27,7 @@ class Sender:
         self.streams = streams if streams is not None else []
         self.processes = processes if processes is not None else {}
         self.jwt = jwt
+        self.internal_port = 5000
 
     def register(self):
         response = self.request("get", f"{DEVICE_ENDPOINT}/{self.serial_number}")


### PR DESCRIPTION
# General info

**Issue Number**: #268

**Task description**: 

 - srt-live-transmit generates SRT stream statistics related to a specific stream which are being saved in `stats/<stream_id>-stats.json`
 - the samples periodically (depending on the frequency defined the config file) send these statistics to our backend
 - statistics stop being sent when the stream is manually closed or deleted from the backend

# Testing

**Test coverage:** n/a

# Additional notes

**Note to reviewers**:
- I've manually tested it locally by force sending dummy statistics data so everything should be fine
- However, before merging this PR we **need** to test it with two devices on different networks
- The investigation I did about SRT stream statistics in https://github.com/bean-pod/switchboard/issues/269 was using an older version of srt-live-transmit and Mohamed implemented the backend endpoint according to that (which is fine). However the newest version of srt-live-transmit sends more statistics so you'll notice I'm doing some preprocessing before sending the stats over to the backend. Our options are either to:
    (1) Preprocess the generated stats on the samples end like I did in this PR
    (2) Adapt the backend endpoint to fit the newest statistics from srt-live-transmit
- Example of statistics file generated for reference
[stats.zip](https://github.com/bean-pod/switchboard-samples/files/6183188/stats.zip)

