### PR TITLE
[#263] Configurable Sender

### DIFF
--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -98,7 +98,7 @@ def start_ffmpeg_file(url, port):
 
 def start_ffmpeg_webcam(webcam, url):
     video_size = "1280x720"
-    framerate = 7.5
+    framerate = "7.5"
     if "camera" in sender.config:
         video_size = sender.config["camera"]["video_size"]
         framerate = sender.config["camera"]["framerate"]

--- a/src/sender-ui.py
+++ b/src/sender-ui.py
@@ -97,11 +97,20 @@ def start_ffmpeg_file(url, port):
 
 
 def start_ffmpeg_webcam(webcam, url):
+    video_size = "1280x720"
+    framerate = 7.5
+    if "camera" in sender.config:
+        video_size = sender.config["camera"]["video_size"]
+        framerate = sender.config["camera"]["framerate"]
     return subprocess.Popen(
         [
             "ffmpeg",
             "-f",
             "dshow",
+            "-video_size",
+            video_size,
+            "-framerate",
+            framerate,
             "-i",
             f"video={webcam}",
             "-f",


### PR DESCRIPTION
# General info

**Issue Number**: #263

**Task description**: 

 - sample sender gets his configuration from the server at start up
 - for now, only the frame rate and video size is configurable

# Testing

**Test coverage:** n/a

# Additional notes

**Note to reviewers**:
- Example configuration file
[example-config.zip](https://github.com/bean-pod/switchboard-samples/files/6287102/example-config.zip)
