### PR TITLE
Changed get device streams endpoint to match a change in the backend

### DIFF
--- a/src/receiver.py
+++ b/src/receiver.py
@@ -69,7 +69,7 @@ class Receiver:
             return "Decoder already registered!"
 
     def get_streams(self):
-        response = self.request("get", f"{DECODER_ENDPOINT}/{self.serial_number}/streams")
+        response = self.request("get", f"{DECODER_ENDPOINT}/{self.serial_number}/stream")
         if response.status_code == 200:
             self.streams = response.json()
 

--- a/src/sender.py
+++ b/src/sender.py
@@ -67,7 +67,7 @@ class Sender:
             return "Encoder already registered!"
 
     def get_streams(self):
-        response = self.request("get", f"{ENCODER_ENDPOINT}/{self.serial_number}/streams")
+        response = self.request("get", f"{ENCODER_ENDPOINT}/{self.serial_number}/stream")
         if response.status_code == 200:
             self.streams = response.json()
 


### PR DESCRIPTION
During some backend fixes the endpoints for get encoder streams and get decoder streams were changed. This PR propagates that change to sample apps.